### PR TITLE
- use official option `--recurse-submodules` in git clone project and…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -155,7 +155,7 @@ Clone the repository and its murmur3 submodule
 
 .. code-block:: bash
 
-    git clone --recursive git@github.com:emcache/emcache
+    git clone --recurse-submodules git@github.com:emcache/emcache
 
 Compile murmur3
 


### PR DESCRIPTION
… subprojects

- `--recurse` option was deprecated